### PR TITLE
Potential fix for code scanning alert no. 103: Use of externally-controlled format string

### DIFF
--- a/home/ubuntu/temp_clasificador_sistema/clasificador-sistema-mejorado/venv/Lib/site-packages/matplotlib/backends/web_backend/js/mpl.js
+++ b/home/ubuntu/temp_clasificador_sistema/clasificador-sistema-mejorado/venv/Lib/site-packages/matplotlib/backends/web_backend/js/mpl.js
@@ -587,7 +587,8 @@ mpl.figure.prototype._make_on_message_function = function (fig) {
                 callback(fig, msg);
             } catch (e) {
                 console.log(
-                    "Exception inside the 'handler_" + msg_type + "' callback:",
+                    "Exception inside the 'handler_%s' callback:",
+                    msg_type,
                     e,
                     e.stack,
                     msg


### PR DESCRIPTION
Potential fix for [https://github.com/bitepass/clasificador_sistema_completo/security/code-scanning/103](https://github.com/bitepass/clasificador_sistema_completo/security/code-scanning/103)

To address the vulnerability, we will sanitize the `msg_type` value before incorporating it into the format string. Specifically, we will use a `%s` format specifier and pass `msg_type` as an argument to the `console.log` function. This approach ensures that the untrusted data is safely handled and prevents format string injection.

Changes to be made:
1. Replace the concatenated string in the `console.log` statement on line 590 with a format string (`"Exception inside the 'handler_%s' callback:"`) that uses `%s` as a placeholder.
2. Pass `msg_type` as an argument to the `console.log` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
